### PR TITLE
Bux fixed for redirecting to the maps page

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -42,7 +42,7 @@ limitations under the License.
   <ul id="main_links">
     <li><a href="/community.html">OUR COMMUNITY</a></li>
     <li><a href="/imaging.jsp">IS THIS AN AVOCADO?</a></li>
-    <li><a href="/maps.html" >CAN I GROW AVOCADOS?</a></li>
+    <li><a href="/map.html" >CAN I GROW AVOCADOS?</a></li>
     <li><a href="/aboutus.html">BEHIND THE SITE</a></li>
   </ul>  
   


### PR DESCRIPTION
Bux founded by @meepitschree . Redirection to the "Can I grow and Avocado?" already works.